### PR TITLE
Fix changelog markdown formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,46 @@
 Change Log
 
-- - -
 ## v0.1.13 (8/25/16)
--- fix request callback parsing for 401 responses
+- fix request callback parsing for 401 responses
+
 ## v0.1.12 (8/24/16)
--- added bot.removeClient route
+- added bot.removeClient route
+
 ## v0.1.11 (8/18/16)
--- new facet to update bot status and status details
+- new facet to update bot status and status details
+
 ## v0.1.10 (8/18/16)
--- new facet incoming message route
+- new facet incoming message route
+
 ## v0.1.9 (8/12/16)
--- added stores.create method
+- added stores.create method
+
 ## v0.1.8 (8/8/16)
--- token can only be passed via constructor
+- token can only be passed via constructor
+
 ## v0.1.7 (8/8/16)
 - added type checking of res.body to avoid doulbe json.Parse()
+
 ## v0.1.6 (8/3/16)
 - fixed dynamic routing type
+
 ## v0.1.5 (8/2/16)
 - added json option to makeAPICall, switched outgoingfile route to json
+
 ## v0.1.4 (8/2/16)
 - Added sendOutgoingFile to bots facet
+
 ## v0.1.3 (5/13/16)
 - Various bug fixes
+
 ## v0.1.2 (5/13/16)
 - Fix module exports error
+
 ## v0.1.1 (4/29/16)
 - Added nodes and stores facets, added addNode method
+
 ## v0.0.1 (2/25/16)
 - Added strict mode
+
 ## v0.0.0 (2/25/16)
 - Hello world.


### PR DESCRIPTION
The changelog markdown had a format issue that caused it to be misrendered in github. Found and fix proposed via: https://changelogs.md/github/lacom/liab-client
